### PR TITLE
Support for binary serialization

### DIFF
--- a/Assets/SerializableDictionary/SerializableDictionary.cs
+++ b/Assets/SerializableDictionary/SerializableDictionary.cs
@@ -21,6 +21,8 @@ public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IS
 			this[kvp.Key] = kvp.Value;
 		}
 	}
+	
+	protected SerializableDictionary(SerializationInfo info, StreamingContext context) : base(info,context){}
 
 	public void CopyFrom(IDictionary<TKey, TValue> dict)
 	{


### PR DESCRIPTION
First of all, thank you for your project. It has helped me a lot :) Now back to the pull request.

Sometimes you want to serialize a dictionary to a file using a binary formatter. However the current implementation doesn't support that.

The constructor added allows child classes of **SerializableDictionary** to be serialized by a **BinaryFormatter**, otherwise it will throw an error if you try to do so. Child classes that want to use this feature will need to define a constructor with the same signature and call the base constructor(SerializableDictionary), passing the parameters. A default constructor will also be needed.

Example of child class that's serializable by a Binary Formatter:

```csharp
[System.Serializable]
public class StringIntDictionary : SerializableDictionary<string,int>
{
    public StringIntDictionary(){}
    public StringIntDictionary(SerializationInfo info, StreamingContext context) : base(info,context){}
}
```
If this feature isn't wanted then the Child class can be left empty, so this won't affect existing projects.
