### PR TITLE
Fix compiler warning in Unity 2018+

### DIFF
--- a/Assets/SerializableDictionary/Example/SerializableDictionaryExample.cs
+++ b/Assets/SerializableDictionary/Example/SerializableDictionaryExample.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class SerializableDictionaryExample : MonoBehaviour {
 	// The dictionaries can be accessed throught a property
 	[SerializeField]
-	StringStringDictionary m_stringStringDictionary;
+	StringStringDictionary m_stringStringDictionary = null;
 	public IDictionary<string, string> StringStringDictionary
 	{
 		get { return m_stringStringDictionary; }


### PR DESCRIPTION
CS0649: field is never assigned to, and will always have its default value null